### PR TITLE
Fix LaTeX math display

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -288,3 +288,8 @@ background: #353534;
 .mwe-popups .mwe-popups-extract[dir="ltr"]::after {
     background-image: unset;
 }
+
+.mwe-math-fallback-image-inline, 
+.mwe-math-fallback-image-display { 
+    filter: invert(1);
+}


### PR DESCRIPTION
LaTeX math is black (on dark grey), this fix makes it white. It's an SVG so we have to invert via filter.

Example: https://en.wikipedia.org/wiki/Algebraic_equation